### PR TITLE
feat: convert to static html landing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "prettier"],
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# testWebIA
+# Landing estática
+
+Landing one-page para **{{NOMBRE_EMPRESA}}** construida con HTML, CSS y JavaScript sencillo. El contenido editable se encuentra en `content/site.json`.
+
+## Uso
+
+1. Clona el repositorio.
+2. Abre `index.html` en tu navegador.
+
+No se requiere build ni dependencias.
+
+## Editar contenido
+
+- Modifica textos y datos de contacto en `content/site.json`.
+- Reemplaza las imágenes en `public/images/` manteniendo los mismos nombres o ajustando las rutas en el JSON.
+
+## Personalización
+
+- Los colores principales se definen como variables CSS en `styles.css`.
+- El tema claro/oscuro se activa con el botón de la barra superior.
+
+## Licencia
+
+MIT

--- a/content/site.json
+++ b/content/site.json
@@ -1,0 +1,19 @@
+{
+  "hero": {
+    "titleWords": ["Webs", "Web Apps", "Marketing Digital", "Chatbots"],
+    "subtitle": "{{ESLOGAN}}",
+    "primaryCta": "Solicitar propuesta",
+    "secondaryCta": "Ver casos"
+  },
+  "services": [
+    { "title": "Desarrollo de sitios web", "description": "Sitios rápidos y accesibles", "icon": "code" },
+    { "title": "Web Apps", "description": "Aplicaciones escalables", "icon": "app" },
+    { "title": "Marketing digital", "description": "SEO, Ads y contenido", "icon": "chart" },
+    { "title": "Chatbots", "description": "Automatización conversacional", "icon": "bot" }
+  ],
+  "contact": {
+    "email": "{{EMAIL}}",
+    "phone": "{{TELEFONO}}",
+    "address": "{{DIRECCION}}"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="es" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{NOMBRE_EMPRESA}}</title>
+  <meta name="description" content="{{ESLOGAN}}" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <img src="public/images/logo.png" alt="Logo {{NOMBRE_EMPRESA}}" class="logo" />
+    <button id="theme-toggle" aria-label="Cambiar tema">🌓</button>
+  </header>
+  <main>
+    <section id="hero">
+      <h1 id="hero-title"></h1>
+      <p id="hero-subtitle"></p>
+      <div class="cta">
+        <a href="#contact" class="btn primary" id="primary-cta"></a>
+        <a href="#services" class="btn secondary" id="secondary-cta"></a>
+      </div>
+    </section>
+    <section id="services">
+      <h2>Servicios</h2>
+      <div id="services-grid" class="grid"></div>
+    </section>
+    <section id="contact">
+      <h2>Contacto</h2>
+      <form id="contact-form">
+        <label>Nombre
+          <input type="text" name="name" required />
+        </label>
+        <label>Email
+          <input type="email" name="email" required />
+        </label>
+        <label>Mensaje
+          <textarea name="message" required></textarea>
+        </label>
+        <button type="submit" class="btn primary">Enviar</button>
+      </form>
+      <div class="contact-data">
+        <p id="contact-email"></p>
+        <p id="contact-phone"></p>
+        <p id="contact-address"></p>
+      </div>
+    </section>
+  </main>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/casos/caso-01.jpg
+++ b/public/images/casos/caso-01.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/hero-01.jpg
+++ b/public/images/hero-01.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/logo.png
+++ b/public/images/logo.png
@@ -1,0 +1,1 @@
+placeholder

--- a/public/images/testimonios/user-01.jpg
+++ b/public/images/testimonios/user-01.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "{{NOMBRE_EMPRESA}}",
+  "short_name": "{{NOMBRE_EMPRESA}}",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0B0F14",
+  "theme_color": "#0B0F14",
+  "icons": [
+    {
+      "src": "/images/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+</urlset>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,41 @@
+async function loadSite() {
+  const res = await fetch('content/site.json');
+  const data = await res.json();
+  const words = data.hero.titleWords;
+  let i = 0;
+  const titleEl = document.getElementById('hero-title');
+  function rotate() {
+    titleEl.textContent = words[i];
+    i = (i + 1) % words.length;
+  }
+  rotate();
+  setInterval(rotate, 2000);
+  document.getElementById('hero-subtitle').textContent = data.hero.subtitle;
+  document.getElementById('primary-cta').textContent = data.hero.primaryCta;
+  document.getElementById('secondary-cta').textContent = data.hero.secondaryCta;
+  const grid = document.getElementById('services-grid');
+  data.services.forEach((s) => {
+    const div = document.createElement('div');
+    div.className = 'card';
+    div.innerHTML = `<h3>${s.title}</h3><p>${s.description}</p>`;
+    grid.appendChild(div);
+  });
+  document.getElementById('contact-email').textContent = data.contact.email;
+  document.getElementById('contact-phone').textContent = data.contact.phone;
+  document.getElementById('contact-address').textContent = data.contact.address;
+}
+loadSite();
+
+const toggle = document.getElementById('theme-toggle');
+toggle.addEventListener('click', () => {
+  const html = document.documentElement;
+  const current = html.getAttribute('data-theme');
+  html.setAttribute('data-theme', current === 'light' ? 'dark' : 'light');
+});
+
+const form = document.getElementById('contact-form');
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  alert('Mensaje enviado (demo)');
+  form.reset();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,81 @@
+:root {
+  --bg: #0B0F14;
+  --surface: #121823;
+  --text: #ffffff;
+  --accent: #00e5ff;
+}
+[data-theme="light"] {
+  --bg: #ffffff;
+  --surface: #f2f2f2;
+  --text: #111111;
+  --accent: #007acc;
+}
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: var(--surface);
+  position: sticky;
+  top: 0;
+}
+.logo { height: 40px; }
+#hero {
+  padding: 4rem 1rem;
+  text-align: center;
+}
+.cta { margin-top: 1rem; display: flex; gap: 1rem; justify-content: center; }
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+  cursor: pointer;
+}
+.btn.primary {
+  background: var(--accent);
+  color: var(--bg);
+}
+.btn.secondary {
+  border: 2px solid var(--accent);
+  color: var(--accent);
+}
+#services {
+  padding: 2rem 1rem;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+.card {
+  background: var(--surface);
+  padding: 1rem;
+  border-radius: 8px;
+}
+#contact {
+  padding: 2rem 1rem;
+}
+#contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+}
+#contact-form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+#contact-form input,
+#contact-form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.contact-data { margin-top: 1rem; }


### PR DESCRIPTION
## Summary
- replace Next.js scaffold with a static HTML/CSS/JS one-page landing
- load hero, services and contact data from JSON file
- add theme toggle and simple contact form

## Testing
- `npm install` *(fails: ENOENT could not read package.json)*
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2cda08cc83228c827c3427dbd815